### PR TITLE
Замена метода "lines" на "lineIterator" для совместимости с JDK11

### DIFF
--- a/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Contexts.scala
@@ -628,7 +628,7 @@ trait Contexts { self: Analyzer =>
 
     def enclosingContextChain: List[Context] = this :: outer.enclosingContextChain
 
-    private def treeTruncated       = tree.toString.replaceAll("\\s+", " ").lines.mkString("\\n").take(70)
+    private def treeTruncated       = tree.toString.replaceAll("\\s+", " ").linesIterator.mkString("\\n").take(70)
     private def treeIdString        = if (settings.uniqid.value) "#" + System.identityHashCode(tree).toString.takeRight(3) else ""
     private def treeString          = tree match {
       case x: Import => "" + x

--- a/src/compiler/scala/tools/nsc/typechecker/Typers.scala
+++ b/src/compiler/scala/tools/nsc/typechecker/Typers.scala
@@ -4667,7 +4667,7 @@ trait Typers extends Adaptations with Tags with TypersTracking with PatternTyper
             if (e.errPos == tree.pos) {
               val header = f"${e.errMsg}%n  Expression does not convert to assignment because:%n    "
               val expansion = f"%n    expansion: ${show(convo)}"
-              NormalTypeError(tree, err.errors.flatMap(_.errMsg.lines.toList).mkString(header, f"%n    ", expansion))
+              NormalTypeError(tree, err.errors.flatMap(_.errMsg.linesIterator.toList).mkString(header, f"%n    ", expansion))
             } else e
           }
         def advice2(errors: List[AbsTypeError]): List[AbsTypeError] =

--- a/src/compiler/scala/tools/util/PathResolver.scala
+++ b/src/compiler/scala/tools/util/PathResolver.scala
@@ -34,7 +34,7 @@ object PathResolver {
   }
   implicit class AsLines(val s: String) extends AnyVal {
     // sm"""...""" could do this in one pass
-    def asLines = s.trim.stripMargin.lines.mkLines
+    def asLines = s.trim.stripMargin.linesIterator.mkLines
   }
 
   /** pretty print class path */

--- a/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTest.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTest.scala
@@ -83,7 +83,7 @@ abstract class InteractiveTest
         loadSources()
         runDefaultTests()
       }
-    }.lines.map(normalize).foreach(println)
+    }.linesIterator.map(normalize).foreach(println)
   }
 
   protected def normalize(s: String) = s

--- a/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTestSettings.scala
+++ b/src/interactive/scala/tools/nsc/interactive/tests/InteractiveTestSettings.scala
@@ -57,7 +57,7 @@ trait InteractiveTestSettings extends TestSettings with PresentationCompilerInst
     val str = try File(optsFile).slurp() catch {
       case e: java.io.IOException => ""
     }
-    str.lines.filter(!_.startsWith(CommentStartDelimiter)).mkString(" ")
+    str.linesIterator.filter(!_.startsWith(CommentStartDelimiter)).mkString(" ")
   }
 
   override protected def printClassPath(implicit reporter: Reporter) {

--- a/src/partest-extras/scala/tools/partest/IcodeComparison.scala
+++ b/src/partest-extras/scala/tools/partest/IcodeComparison.scala
@@ -53,7 +53,7 @@ abstract class IcodeComparison extends DirectTest {
     // here depends on it (collectIcode will be called multiple times, and we can't allow crosstalk
     // between calls).  So we are careful to use `slurp` which does call `close`, and careful to
     // check that `delete` returns true indicating successful deletion.
-    try     icodeFiles sortBy (_.name) flatMap (f => f.slurp().lines.toList)
+    try     icodeFiles sortBy (_.name) flatMap (f => f.slurp().linesIterator.toList)
     finally icodeFiles foreach (f => require(f.delete()))
   }
 

--- a/src/partest-extras/scala/tools/partest/ReplTest.scala
+++ b/src/partest-extras/scala/tools/partest/ReplTest.scala
@@ -32,7 +32,7 @@ abstract class ReplTest extends DirectTest {
     log("eval(): settings = " + s)
     val transcript = ILoop.runForTranscript(code, s, inSession = inSession)
     log(s"transcript[[$transcript]]")
-    val lines = transcript.lines
+    val lines = transcript.linesIterator
     val clean =
       if (welcoming) {
         val welcome = "(Welcome to Scala).*".r
@@ -41,7 +41,7 @@ abstract class ReplTest extends DirectTest {
           case s          => s
         }
       } else {
-        lines.drop(header.lines.size)
+        lines.drop(header.linesIterator.size)
       }
     clean.map(normalize)
   }
@@ -61,7 +61,7 @@ abstract class SessionTest extends ReplTest  {
   def session: String = testPath.changeExtension("check").toFile.slurp
 
   /** Expected output, as an iterator, optionally marginally stripped. */
-  def expected = if (stripMargins) session.stripMargin.lines else session.lines
+  def expected = if (stripMargins) session.stripMargin.linesIterator else session.linesIterator
 
   /** Override with true if session is a """string""" with margin indent. */
   def stripMargins: Boolean = false

--- a/src/reflect/scala/reflect/internal/Printers.scala
+++ b/src/reflect/scala/reflect/internal/Printers.scala
@@ -1047,7 +1047,7 @@ trait Printers extends api.Printers { self: SymbolTable =>
 
         case Literal(k @ Constant(s: String)) if s.contains(Chars.LF) =>
           val tq = "\"" * 3
-          val lines = s.lines.toList
+          val lines = s.linesIterator.toList
           if (lines.lengthCompare(1) <= 0) print(k.escapedStringValue)
           else {
             val tqp = """["]{3}""".r

--- a/src/reflect/scala/reflect/internal/util/StringOps.scala
+++ b/src/reflect/scala/reflect/internal/util/StringOps.scala
@@ -45,7 +45,7 @@ trait StringOps {
     else s.substring(0, end)
   }
   /** Breaks the string into lines and strips each line before reassembling. */
-  def trimAllTrailingSpace(s: String): String = s.lines.map(trimTrailingSpace).mkString(EOL)
+  def trimAllTrailingSpace(s: String): String = s.linesIterator.map(trimTrailingSpace).mkString(EOL)
 
   def decompose(str: String, sep: Char): List[String] = {
     def ws(start: Int): List[String] =

--- a/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineHistory.scala
+++ b/src/repl-jline/scala/tools/nsc/interpreter/jline/JLineHistory.scala
@@ -40,7 +40,7 @@ trait JLineHistory extends JHistory with History {
   def moveToEnd(): Unit
 
   override def historicize(text: String): Boolean = {
-    text.lines foreach add
+    text.linesIterator foreach add
     moveToEnd()
     true
   }

--- a/src/repl/scala/tools/nsc/interpreter/ILoop.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ILoop.scala
@@ -556,7 +556,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter) extend
               tmp.safeSlurp() match {
                 case Some(edited) if edited.trim.isEmpty => echo("Edited text is empty.")
                 case Some(edited) =>
-                  echo(edited.lines map ("+" + _) mkString "\n")
+                  echo(edited.linesIterator map ("+" + _) mkString "\n")
                   val res = intp interpret edited
                   if (res == IR.Incomplete) diagnose(edited)
                   else {
@@ -787,7 +787,7 @@ class ILoop(in0: Option[BufferedReader], protected val out: JPrintWriter) extend
         val input = readWhile(s => delimiter.isEmpty || delimiter.get != s) mkString "\n"
         val text = (
           margin filter (_.nonEmpty) map {
-            case "-" => input.lines map (_.trim) mkString "\n"
+            case "-" => input.linesIterator map (_.trim) mkString "\n"
             case m   => input stripMargin m.head   // ignore excess chars in "<<||"
           } getOrElse input
         ).trim

--- a/src/repl/scala/tools/nsc/interpreter/IMain.scala
+++ b/src/repl/scala/tools/nsc/interpreter/IMain.scala
@@ -572,7 +572,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
         if (printResults && result != "")
           printMessage(result stripSuffix "\n")
         else if (isReplDebug) // show quiet-mode activity
-          printMessage(result.trim.lines map ("[quiet] " + _) mkString "\n")
+          printMessage(result.trim.linesIterator map ("[quiet] " + _) mkString "\n")
 
         // Book-keeping.  Have to record synthetic requests too,
         // as they may have been issued for information, e.g. :type
@@ -1213,7 +1213,7 @@ class IMain(initialSettings: Settings, protected val out: JPrintWriter) extends 
     /** Secret bookcase entrance for repl debuggers: end the line
      *  with "// show" and see what's going on.
      */
-    def isShow = code.lines exists (_.trim endsWith "// show")
+    def isShow = code.linesIterator exists (_.trim endsWith "// show")
     if (isReplDebug || isShow) {
       beSilentDuring(parse(code)) match {
         case parse.Success(ts) =>

--- a/src/repl/scala/tools/nsc/interpreter/Pasted.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Pasted.scala
@@ -19,7 +19,7 @@ abstract class Pasted(prompt: String) {
   def interpret(line: String): IR.Result
   def echo(message: String): Unit
 
-  val PromptString    = prompt.lines.toList.last
+  val PromptString    = prompt.linesIterator.toList.last
   val AltPromptString = "scala> "
   val ContinuePrompt  = replProps.continuePrompt
   val ContinueString  = replProps.continueText     // "     | "

--- a/src/repl/scala/tools/nsc/interpreter/Power.scala
+++ b/src/repl/scala/tools/nsc/interpreter/Power.scala
@@ -139,7 +139,7 @@ class Power[ReplValsImpl <: ReplVals : ru.TypeTag: ClassTag](val intp: IMain, re
     |definitions.{ getClass => _, _ }
     |power.rutil._
     |replImplicits._
-    |treedsl.CODE._""".stripMargin.lines
+    |treedsl.CODE._""".stripMargin.linesIterator
 
   def init = customInit getOrElse initImports.mkString("import ", ", ", "")
 
@@ -151,7 +151,7 @@ class Power[ReplValsImpl <: ReplVals : ru.TypeTag: ClassTag](val intp: IMain, re
     // Then we import everything from $r.
     intp interpret s"import ${ intp.originalPath("$r") }._"
     // And whatever else there is to do.
-    init.lines foreach (intp interpret _)
+    init.linesIterator foreach (intp interpret _)
   }
 
   trait LowPriorityInternalInfo {

--- a/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplProps.scala
@@ -52,7 +52,7 @@ class ReplProps {
   val continueString = Prop[String]("scala.repl.continue").option getOrElse "| "
   val continueText   = {
     val text   = enversion(continueString)
-    val margin = promptText.lines.toList.last.length - text.length
+    val margin = promptText.linesIterator.toList.last.length - text.length
     if (margin > 0) " " * margin + text else text
   }
   val continuePrompt = encolor(continueText)

--- a/src/repl/scala/tools/nsc/interpreter/ReplReporter.scala
+++ b/src/repl/scala/tools/nsc/interpreter/ReplReporter.scala
@@ -54,7 +54,7 @@ class ReplReporter(intp: IMain) extends ConsoleReporter(intp.settings, Console.i
     case INFO    => RESET
   }
 
-  private val promptLength = replProps.promptText.lines.toList.last.length
+  private val promptLength = replProps.promptText.linesIterator.toList.last.length
   private val indentation  = " " * promptLength
 
   // colorized console labels

--- a/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
+++ b/src/scaladoc/scala/tools/nsc/doc/base/CommentFactoryBase.scala
@@ -215,7 +215,7 @@ trait CommentFactoryBase { this: MemberLookupBase =>
         SafeTags.replaceAllIn(javadoclessComment, { mtch =>
           java.util.regex.Matcher.quoteReplacement(safeTagMarker + mtch.matched + safeTagMarker)
         })
-      markedTagComment.lines.toList map (cleanLine(_))
+      markedTagComment.linesIterator.toList map (cleanLine(_))
     }
 
     /** Parses a comment (in the form of a list of lines) to a `Comment`

--- a/test/junit/scala/io/SourceTest.scala
+++ b/test/junit/scala/io/SourceTest.scala
@@ -26,7 +26,7 @@ class SourceTest {
   private def in = new ByteArrayInputStream(sampler.getBytes)
 
   @Test def canIterateLines() = {
-    assertEquals(sampler.lines.size, (Source fromString sampler).getLines.size)
+    assertEquals(sampler.linesIterator.size, (Source fromString sampler).getLines.size)
   }
   @Test def loadFromResource() = {
     val res = Source.fromResource("rootdoc.txt")

--- a/test/junit/scala/lang/stringinterpol/StringContextTest.scala
+++ b/test/junit/scala/lang/stringinterpol/StringContextTest.scala
@@ -246,7 +246,7 @@ class StringContextTest {
       f" mind%n------%nmatter" ->
        """| mind
           |------
-          |matter""".stripMargin.lines.mkString(compat.Platform.EOL),
+          |matter""".stripMargin.linesIterator.mkString(compat.Platform.EOL),
       f"${i}%d %<d ${9}%d"   -> "42 42 9",
       f"${7}%d %<d ${9}%d"   -> "7 7 9",
       f"${7}%d %2$$d ${9}%d" -> "7 9 9",

--- a/test/junit/scala/reflect/internal/PrintersTest.scala
+++ b/test/junit/scala/reflect/internal/PrintersTest.scala
@@ -13,7 +13,7 @@ object PrinterHelper {
 
   import scala.reflect.internal.Chars._
   private def normalizeEOL(resultCode: String) =
-    resultCode.lines mkString s"$LF"
+    resultCode.linesIterator mkString s"$LF"
 
   def assertResultCode(code: String)(parsedCode: String = "", typedCode: String = "", wrap: Boolean = false, printRoot: Boolean = false) = {
     def toolboxTree(tree: => Tree) = try {
@@ -31,7 +31,7 @@ object PrinterHelper {
       |  class foo3[Af, Bf](a: scala.Int)(b: scala.Float, c: PrintersContext.this.foo1[Af, Bf]) extends scala.annotation.Annotation with scala.annotation.StaticAnnotation;
       |  trait A1;
       |  trait B1;
-      |${source.trim.lines map {"  " + _} mkString s"$LF"}
+      |${source.trim.linesIterator map {"  " + _} mkString s"$LF"}
       |}"""
 
       if (wrap) context.trim() else source.trim

--- a/test/junit/scala/tools/nsc/interpreter/ScriptedTest.scala
+++ b/test/junit/scala/tools/nsc/interpreter/ScriptedTest.scala
@@ -90,7 +90,7 @@ class ScriptedTest {
     ctx.setErrorWriter(err)
     ctx.setReader(in)
     engine.eval(code, ctx)
-    val lines = text.lines.toList
+    val lines = text.linesIterator.toList
     assertEquals(lines.head + EOL + lines.last + EOL, out.toString)
     assertEquals(lines(1) + EOL, err.toString)
   }

--- a/test/junit/scala/tools/nsc/reporters/ConsoleReporterTest.scala
+++ b/test/junit/scala/tools/nsc/reporters/ConsoleReporterTest.scala
@@ -36,9 +36,9 @@ class ConsoleReporterTest {
     test(pos)
     if (msg.isEmpty && severity.isEmpty) assertTrue(writerOut.toString.isEmpty)
     else {
-      if (!pos.isDefined) assertEquals(severity + msg, writerOut.toString.lines.next)
+      if (!pos.isDefined) assertEquals(severity + msg, writerOut.toString.linesIterator.next)
       else {
-        val it = writerOut.toString.lines
+        val it = writerOut.toString.linesIterator
         assertEquals(source + ":1: " + severity + msg, it.next)
         assertEquals(content, it.next)
         assertEquals("    ^", it.next)
@@ -61,7 +61,7 @@ class ConsoleReporterTest {
   def echoTest(): Unit = {
     val reporter = createConsoleReporter("r", writerOut, echoWriterOut)
     reporter.echo("Hello World!")
-    assertEquals("Hello World!", echoWriterOut.toString.lines.next)
+    assertEquals("Hello World!", echoWriterOut.toString.linesIterator.next)
 
     /** Check with constructor which has the same writer and echoWriter */
     val reporter2 = createConsoleReporter("r", writerOut)
@@ -87,7 +87,7 @@ class ConsoleReporterTest {
     testHelper(msg = "")(reporter.printColumnMarker(_))
 
     reporter.printColumnMarker(posWithSource)
-    assertEquals("    ^", writerOut.toString.lines.next)
+    assertEquals("    ^", writerOut.toString.linesIterator.next)
     writerOut.reset
   }
 
@@ -133,7 +133,7 @@ class ConsoleReporterTest {
     reporter.ERROR.count = 10
     reporter.WARNING.count = 3
     reporter.finish()
-    val it = writerOut.toString.lines
+    val it = writerOut.toString.linesIterator
     assertEquals("three warnings found", it.next)
     assertEquals("10 errors found", it.next)
     writerOut.reset
@@ -147,7 +147,7 @@ class ConsoleReporterTest {
     /** Check for stack trace */
     val reporter = createConsoleReporter("s", writerOut, echoWriterOut)
     reporter.displayPrompt()
-    val it = writerOut.toString.lines
+    val it = writerOut.toString.linesIterator
     assertTrue(it.next.isEmpty)
     assertEquals(output + "java.lang.Throwable", it.next)
     assertTrue(it.hasNext)
@@ -156,7 +156,7 @@ class ConsoleReporterTest {
     val writerOut2 = new ByteArrayOutputStream()
     val reporter2 = createConsoleReporter("w", writerOut2)
     reporter2.displayPrompt()
-    val it2 = writerOut2.toString.lines
+    val it2 = writerOut2.toString.linesIterator
     assertTrue(it2.next.isEmpty)
     assertEquals(output, it2.next)
     assertFalse(it2.hasNext)
@@ -165,7 +165,7 @@ class ConsoleReporterTest {
     val writerOut3 = new ByteArrayOutputStream()
     val reporter3 = createConsoleReporter("r", writerOut3)
     reporter3.displayPrompt()
-    val it3 = writerOut3.toString.lines
+    val it3 = writerOut3.toString.linesIterator
     assertTrue(it3.next.isEmpty)
     assertEquals(output, it3.next)
     assertFalse(it3.hasNext)

--- a/test/junit/scala/tools/nsc/settings/SettingsTest.scala
+++ b/test/junit/scala/tools/nsc/settings/SettingsTest.scala
@@ -184,7 +184,7 @@ class SettingsTest {
 
   // equal with stripped margins and normalized line endings
   private def marginallyEquals(s1: String, s2: String): Boolean = {
-    def normally(s: String): String = s.stripMargin.lines.mkString("\n")
+    def normally(s: String): String = s.stripMargin.linesIterator.mkString("\n")
     normally(s1) == normally(s2)
   }
 

--- a/test/junit/scala/tools/nsc/util/StackTraceTest.scala
+++ b/test/junit/scala/tools/nsc/util/StackTraceTest.scala
@@ -72,7 +72,7 @@ class StackTraceTest extends Expecting {
 
   @Test def showsAllTrace() {
     probe(sampler)(_ => true) { s =>
-      val res = s.lines.toList
+      val res = s.linesIterator.toList
       /*
       expect {
         res.length > 5  // many lines
@@ -85,7 +85,7 @@ class StackTraceTest extends Expecting {
     }
   }
   @Test def showsOnlyPrefix() = probe(sample)(_.getMethodName == "sample") { s =>
-    val res = s.lines.toList
+    val res = s.linesIterator.toList
     /*
     expect {
       res.length == 3   // summary + one frame + elision
@@ -94,7 +94,7 @@ class StackTraceTest extends Expecting {
     assert (res.length == 3)
   }
   @Test def showsCause() = probe(resampler)(_.getMethodName != "resampler") { s =>
-    val res = s.lines.toList
+    val res = s.linesIterator.toList
     /*
     expect {
       res.length == 6   // summary + one frame + elision, caused by + one frame + elision
@@ -105,7 +105,7 @@ class StackTraceTest extends Expecting {
     assert (res exists (_ startsWith CausedBy.toString))
   }
   @Test def showsWrappedExceptions() = probe(rewrapperer)(_.getMethodName != "rewrapperer") { s =>
-    val res = s.lines.toList
+    val res = s.linesIterator.toList
     /*
     expect {
       res.length == 9   // summary + one frame + elision times three
@@ -122,7 +122,7 @@ class StackTraceTest extends Expecting {
       }).size == 2)
   }
   @Test def dontBlowOnCycle() = probe(insaner)(_.getMethodName != "insaner") { s =>
-    val res = s.lines.toList
+    val res = s.linesIterator.toList
     /*
     expect {
       res.length == 7   // summary + one frame + elision times two with extra frame
@@ -144,7 +144,7 @@ java.lang.RuntimeException: My problem
     ... 27 more
   */
   @Test def showsSuppressed() = probe(represser)(_.getMethodName != "represser") { s =>
-    val res = s.lines.toList
+    val res = s.linesIterator.toList
     if (suppressable) {
       assert (res.length == 7)
       assert (res exists (_.trim startsWith Suppressed.toString))


### PR DESCRIPTION
Методы "lines" и "lineIterator" имеют идентичную реализацию, регрессии не будет.
Метод "lines" появился в JDK11, поэтому scala с ним конфликтует